### PR TITLE
Adds locking to avoid dpkg install conflicts

### DIFF
--- a/jobs/omsagent/templates/install.erb
+++ b/jobs/omsagent/templates/install.erb
@@ -95,7 +95,10 @@ EOF
 
 # Install packages
 if [ ${DPKG_FOUND} -eq 0 ]; then
+    (
+    flock -x 200
     dpkg -i --force-confold --force-confdef /var/vcap/packages/omsagent/omi*.deb /var/vcap/packages/omsagent/scx*.deb /var/vcap/packages/omsagent/omsagent*.deb /var/vcap/packages/omsagent/omsconfig*.deb
+    ) 200>/var/vcap/data/dpkg.lock
 else
     rpm -Uvh --force /var/vcap/packages/omsagent/omi-*.rpm /var/vcap/packages/omsagent/scx*.rpm /var/vcap/packages/omsagent/omsagent*.rpm /var/vcap/packages/omsagent/omsconfig*.rpm
 fi


### PR DESCRIPTION
We ran into an issue where bosh addons can have dkpg install conflicts with the `nfsv3driver` component in PAS where we will see an error similar to: `dpkg: error: dpkg frontend is locked by another process`.

This patch adds a lock file to prevent multiple installs from kicking off at the same time.