### PR TITLE
path to release typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ To use this bosh release, first upload it to your BOSH Director:
 
 ```
 # BOSH CLI v1
-bosh upload release https://github.com/Azure/oms-agent-for-linux-boshrelease/releases/download/v1.9.0-0/oms-agent-for-linux-1.9.0-0.tgz
+bosh upload release https://github.com/Azure/oms-agent-for-linux-boshrelease/releases/download/v1.9.0-0/oms-agent-for-linux-boshrelease-1.9.0-0.tar.gz
 
 # BOSH CLI v2
-bosh2 upload-release https://github.com/Azure/oms-agent-for-linux-boshrelease/releases/download/v1.9.0-0/oms-agent-for-linux-1.9.0-0.tgz
+bosh2 upload-release https://github.com/Azure/oms-agent-for-linux-boshrelease/releases/download/v1.9.0-0/oms-agent-for-linux-boshrelease-1.9.0-0.tar.gz
 ```
 
 ### 2. Deploy as a BOSH addon


### PR DESCRIPTION
Upload Release instructions are pointing to incorrect path to release.
Example: ```bosh2 upload-release https://github.com/Azure/oms-agent-for-linux-boshrelease/releases/download/v1.9.0-0/oms-agent-for-linux-1.9.0-0.tgz```
Correct Path: ```https://github.com/Azure/oms-agent-for-linux-boshrelease/releases/download/v1.9.0-0/oms-agent-for-linux-boshrelease-1.9.0-0.tar.gz```